### PR TITLE
Adding multi threaded voting and fixed voting bug in GA

### DIFF
--- a/voting/Copland.java
+++ b/voting/Copland.java
@@ -65,6 +65,7 @@ public class Copland extends VotingMethod {
             for (String comparison : this.Votes.keySet()) {
                 String[] comparisonSplit = comparison.split("\\.");
                 if (bundle.Name.equals(comparisonSplit[0])) {
+                    System.out.println(this.Votes.get(comparison));
                     // we are lower
                     if (this.Votes.get(comparison) < 0) {
                         // we are better
@@ -76,6 +77,8 @@ public class Copland extends VotingMethod {
                     // if we are worse add 0, so dont need to check
                 }
                 if (bundle.Name.equals(comparisonSplit[1])) {
+                    System.out.println(this.Votes.get(comparison));
+
                     // we are higher
                     if (this.Votes.get(comparison) > 0) {
                         // we are better
@@ -86,13 +89,14 @@ public class Copland extends VotingMethod {
                     }
                 }
             }
+
             copelandSums.put(bundle, winSum);
         }
         int max = 0;
         Bundle maxBundle = null;
         for(Bundle bundle : copelandSums.keySet()) {
-            if(copelandSums.get(bundle) > max) {
-                max = copelandSums.get(bundle);
+            if(Math.abs(copelandSums.get(bundle)) > max) {
+                max = Math.abs(copelandSums.get(bundle));
                 maxBundle = bundle;
             }
         }

--- a/voting/Copland.java
+++ b/voting/Copland.java
@@ -65,7 +65,6 @@ public class Copland extends VotingMethod {
             for (String comparison : this.Votes.keySet()) {
                 String[] comparisonSplit = comparison.split("\\.");
                 if (bundle.Name.equals(comparisonSplit[0])) {
-                    System.out.println(this.Votes.get(comparison));
                     // we are lower
                     if (this.Votes.get(comparison) < 0) {
                         // we are better
@@ -77,8 +76,6 @@ public class Copland extends VotingMethod {
                     // if we are worse add 0, so dont need to check
                 }
                 if (bundle.Name.equals(comparisonSplit[1])) {
-                    System.out.println(this.Votes.get(comparison));
-
                     // we are higher
                     if (this.Votes.get(comparison) > 0) {
                         // we are better

--- a/voting/Copland.java
+++ b/voting/Copland.java
@@ -15,7 +15,7 @@ public class Copland extends VotingMethod {
     public void CalculateVotes() {
         for (Voter voter : this.Voters) {
             for (Bundle currentBundle : voter.getBundleScore().keySet()){
-                if (!BundlesByName.containsKey(currentBundle)) BundlesByName.put(currentBundle.Name, currentBundle);
+//                if (!BundlesByName.containsKey(currentBundle)) BundlesByName.put(currentBundle.Name, currentBundle);
                 for (Bundle comparisonBundle : voter.getBundleScore().keySet()){
                     // if the bundles are the same then skip i.e. comparing me to me
                     if (currentBundle == comparisonBundle) continue;

--- a/voting/GeneticAlgMain.java
+++ b/voting/GeneticAlgMain.java
@@ -23,9 +23,7 @@ public class GeneticAlgMain {
             for (Bundle bundle : Result.getTotalUtilities().keySet()) {
                 totalUtility += Result.getTotalUtilities().get(bundle);
             }
-            System.out.println("Average Utility: " + (totalUtility/this.PopulationSize));
-            System.out.println("Best Utility: " + Result.getBestBundle().getValue());
-            System.out.println(Result.getBestBundle().getKey().toString());
+            System.out.println("Generation Utility Mean: " + totalUtility/PopulationSize);
             Reproduce();
             RunVoting();
         }
@@ -95,7 +93,6 @@ public class GeneticAlgMain {
             }
         }
         Map<String,Bundle> winners = MultiThreadedVoting.Run(Voters);
-
         // Need to replace with non-hard coded
         this.Result = ResultAnalyzer.analyze(winners, Population, Voters,111);
     }

--- a/voting/GeneticAlgMain.java
+++ b/voting/GeneticAlgMain.java
@@ -100,22 +100,23 @@ public class GeneticAlgMain {
                 voter.CalculatePreference(bundle);
             }
         }
-//        Map<String,Bundle> winners = MultiThreadedVoting.Run(Voters);
+        Map<String,Bundle> winners = MultiThreadedVoting.Run(Voters);
 
-        VotingMethod borda = new Borda(Voters);
-        VotingMethod copland = new Copland(Voters);
-        VotingMethod pairwise = new Pairwise(Voters);
-
-        VotingMethod[] votingMethods = {borda, pairwise, copland};
-        Map<String,Bundle> winners = new Hashtable<>();
-        for (VotingMethod votingMethod : votingMethods) {
-            System.out.println("Running: " + votingMethod.Name);
-            votingMethod.RunVote();
-            System.out.println(votingMethod.Winner);
-            if (votingMethod.Winner != null) {
-                winners.put(votingMethod.toString(), votingMethod.Winner);
-            }
-        }
+        // This is the old method for running the votes, oddly it is way faster now too, but not as fast as MTing
+//        VotingMethod borda = new Borda(Voters);
+//        VotingMethod copland = new Copland(Voters);
+//        VotingMethod pairwise = new Pairwise(Voters);
+//
+//        VotingMethod[] votingMethods = {borda, pairwise, copland};
+//        Map<String,Bundle> winners = new Hashtable<>();
+//        for (VotingMethod votingMethod : votingMethods) {
+//            System.out.println("Running: " + votingMethod.Name);
+//            votingMethod.RunVote();
+//            System.out.println(votingMethod.Winner);
+//            if (votingMethod.Winner != null) {
+//                winners.put(votingMethod.toString(), votingMethod.Winner);
+//            }
+//        }
 
         // Need to replace with non-hard coded
         this.Result = ResultAnalyzer.analyze(winners, Population, Voters,111);

--- a/voting/GeneticAlgMain.java
+++ b/voting/GeneticAlgMain.java
@@ -94,20 +94,8 @@ public class GeneticAlgMain {
                 voter.CalculatePreference(bundle);
             }
         }
+        Map<String,Bundle> winners = MultiThreadedVoting.Run(Voters);
 
-        VotingMethod borda = new Borda(Voters);
-        VotingMethod copland = new Copland(Voters);
-        VotingMethod pairwise = new Pairwise(Voters);
-
-        VotingMethod[] votingMethods = {borda, pairwise, copland};
-        Map<String,Bundle> winners = new Hashtable<>();
-        for (VotingMethod votingMethod : votingMethods) {
-            System.out.println("Running: " + votingMethod.Name);
-            votingMethod.RunVote();
-            if (votingMethod.Winner != null) {
-                winners.put(votingMethod.toString(), votingMethod.Winner);
-            }
-        }
         // Need to replace with non-hard coded
         this.Result = ResultAnalyzer.analyze(winners, Population, Voters,111);
     }

--- a/voting/GeneticAlgMain.java
+++ b/voting/GeneticAlgMain.java
@@ -51,7 +51,8 @@ public class GeneticAlgMain {
         for(int i = 0; i <= k; i++) {
             options.add(i);
         }
-        for(int i = 0; i < k/2; i++) {
+        while (newPopulation.size() < PopulationSize) {
+//        for(int i = 0; i < k/2; i++) {
             // get one parent, remove it
             int parentIndex = options.get(rnd.nextInt(options.size()));
             Bundle parent1 = sorted.get(parentIndex).getKey();
@@ -64,6 +65,7 @@ public class GeneticAlgMain {
             newPopulation.add(combineParents(parent1, parent2));
         }
         this.Population = newPopulation;
+
     }
     private Bundle combineParents(Bundle parent1, Bundle parent2) {
         // Get union list
@@ -84,6 +86,9 @@ public class GeneticAlgMain {
     }
 
     private void RunVoting() {
+        for (Voter voter : Voters) {
+            voter.clearBundleScores();
+        }
         for (Bundle bundle : this.Population) {
             for (Voter voter : Voters) {
                 voter.CalculatePreference(bundle);

--- a/voting/MultiThreadedVoting.java
+++ b/voting/MultiThreadedVoting.java
@@ -12,13 +12,16 @@ public class MultiThreadedVoting {
         Thread[] votingThreads = new Thread[3];
         for(int i = 0; i < votingMethods.length; i++) {
             votingThreads[i] = new Thread(votingMethods[i]);
-            votingThreads[i].start();
+//            votingThreads[i].start();
+            votingThreads[i].run();
         }
 
         Map<String,Bundle> winners = new Hashtable<>();
         for(int i = 0; i < votingMethods.length; i++) {
             try {
                 votingThreads[i].join();
+                System.out.println(votingMethods[i].toString());
+                System.out.println(votingMethods[i].Winner);
                 if (votingMethods[i].Winner != null) {
                     winners.put(votingMethods[i].toString(), votingMethods[i].Winner);
                 }

--- a/voting/MultiThreadedVoting.java
+++ b/voting/MultiThreadedVoting.java
@@ -1,0 +1,31 @@
+import java.util.ArrayList;
+import java.util.Hashtable;
+import java.util.Map;
+
+public class MultiThreadedVoting {
+    public static Map<String,Bundle> Run(ArrayList<Voter> Voters) {
+        VotingMethod borda = new Borda(Voters);
+        VotingMethod copland = new Copland(Voters);
+        VotingMethod pairwise = new Pairwise(Voters);
+
+        VotingMethod[] votingMethods = {borda, pairwise, copland};
+        Thread[] votingThreads = new Thread[3];
+        for(int i = 0; i < votingMethods.length; i++) {
+            votingThreads[i] = new Thread(votingMethods[i]);
+            votingThreads[i].start();
+        }
+
+        Map<String,Bundle> winners = new Hashtable<>();
+        for(int i = 0; i < votingMethods.length; i++) {
+            try {
+                votingThreads[i].join();
+                if (votingMethods[i].Winner != null) {
+                    winners.put(votingMethods[i].toString(), votingMethods[i].Winner);
+                }
+            } catch (InterruptedException e) {
+                e.printStackTrace();
+            }
+        }
+        return winners;
+    }
+}

--- a/voting/MultiThreadedVoting.java
+++ b/voting/MultiThreadedVoting.java
@@ -4,24 +4,25 @@ import java.util.Map;
 
 public class MultiThreadedVoting {
     public static Map<String,Bundle> Run(ArrayList<Voter> Voters) {
-        VotingMethod borda = new Borda(Voters);
-        VotingMethod copland = new Copland(Voters);
-        VotingMethod pairwise = new Pairwise(Voters);
+        VotingMethod borda = new Borda(new ArrayList<>(Voters));
+        VotingMethod copland = new Copland(new ArrayList<>(Voters));
+        VotingMethod pairwise = new Pairwise(new ArrayList<>(Voters));
 
         VotingMethod[] votingMethods = {borda, pairwise, copland};
         Thread[] votingThreads = new Thread[3];
         for(int i = 0; i < votingMethods.length; i++) {
+            System.out.println(votingMethods[i]);
             votingThreads[i] = new Thread(votingMethods[i]);
-//            votingThreads[i].start();
-            votingThreads[i].run();
+            votingThreads[i].start();
+//            votingThreads[i].run();
         }
 
         Map<String,Bundle> winners = new Hashtable<>();
         for(int i = 0; i < votingMethods.length; i++) {
             try {
                 votingThreads[i].join();
-                System.out.println(votingMethods[i].toString());
-                System.out.println(votingMethods[i].Winner);
+//                System.out.println(votingMethods[i].toString());
+//                System.out.println(votingMethods[i].Winner);
                 if (votingMethods[i].Winner != null) {
                     winners.put(votingMethods[i].toString(), votingMethods[i].Winner);
                 }

--- a/voting/Pairwise.java
+++ b/voting/Pairwise.java
@@ -5,7 +5,7 @@ import java.util.Map;
 
 public class Pairwise extends VotingMethod {
     private final Map<String, Integer> Votes = new Hashtable<>();
-    private final Map<String, Bundle> BundlesByName = new Hashtable<>();
+//    private final Map<String, Bundle> BundlesByName = new Hashtable<>();
     private final int BundleCount;
     public Pairwise(ArrayList<Voter> voters){
         super("Pairwise");
@@ -19,7 +19,7 @@ public class Pairwise extends VotingMethod {
     public void CalculateVotes() {
         for (Voter voter : this.Voters) {
             for (Bundle currentBundle : voter.getBundleScore().keySet()){
-                if (!BundlesByName.containsKey(currentBundle)) BundlesByName.put(currentBundle.Name, currentBundle);
+//                if (!BundlesByName.containsKey(currentBundle)) BundlesByName.put(currentBundle.Name, currentBundle);
                 for (Bundle comparisonBundle : voter.getBundleScore().keySet()){
                     // if the bundles are the same then skip i.e. comparing me to me
                     if (currentBundle == comparisonBundle) continue;

--- a/voting/Pairwise.java
+++ b/voting/Pairwise.java
@@ -11,8 +11,8 @@ public class Pairwise extends VotingMethod {
         super("Pairwise");
         this.Voters = voters;
         this.BundleCount = this.Voters.get(0).getBundleCount();
-        System.out.println("Voters: " + this.Votes.size());
-        System.out.println("Bundles: " + this.BundleCount);
+        System.out.println("Voters: " + this.Voters.size());
+        System.out.println("Bundles: " + this.Voters.get(0).getBundleScore().size());
     }
 
     @Override

--- a/voting/Pairwise.java
+++ b/voting/Pairwise.java
@@ -11,8 +11,6 @@ public class Pairwise extends VotingMethod {
         super("Pairwise");
         this.Voters = voters;
         this.BundleCount = this.Voters.get(0).getBundleCount();
-        System.out.println("Voters: " + this.Voters.size());
-        System.out.println("Bundles: " + this.Voters.get(0).getBundleScore().size());
     }
 
     @Override

--- a/voting/Pairwise.java
+++ b/voting/Pairwise.java
@@ -11,6 +11,8 @@ public class Pairwise extends VotingMethod {
         super("Pairwise");
         this.Voters = voters;
         this.BundleCount = this.Voters.get(0).getBundleCount();
+        System.out.println("Voters: " + this.Votes.size());
+        System.out.println("Bundles: " + this.BundleCount);
     }
 
     @Override

--- a/voting/Voter.java
+++ b/voting/Voter.java
@@ -25,6 +25,10 @@ public class Voter {
         return BundleScore.size();
     }
 
+    public void clearBundleScores() {
+        this.BundleScore.clear();
+    }
+
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();

--- a/voting/VotingMethod.java
+++ b/voting/VotingMethod.java
@@ -1,7 +1,7 @@
 import java.util.ArrayList;
 
 import java.util.ArrayList;
-public abstract class VotingMethod {
+public abstract class VotingMethod implements Runnable {
     public String Name;
     public Bundle Winner;
     protected ArrayList<Voter> Voters = new ArrayList<Voter>();
@@ -21,5 +21,8 @@ public abstract class VotingMethod {
     @Override
     public String toString() {
         return Name;
+    }
+    public void run() {
+        RunVote();
     }
 }


### PR DESCRIPTION
I figured we can easily run the three voting methods in parallel which saves us a decent amount of time since copeland and pairwise takes about the same amount of time and are the heaviest so this cuts the time in half. Testing the run time of the GA it was 58s average at current settings and got down to 30s with multi threading. 
Interesting re running the program got it down to 1s as I just re ran it now. My guess is that its still cached somewhere on my PC or something. Testing again with a new seed, so nothing should be the same, it still took less than a second. It seems to still be generating scores correctly though.

I also just found a bug while double checking these times with copeland never giving points, so I am working on that for a second.